### PR TITLE
meson: apply `bin` tag to tools

### DIFF
--- a/include/dicom/dicom.h
+++ b/include/dicom/dicom.h
@@ -461,7 +461,7 @@ typedef enum _DcmVR {
  * DCM_CLASS_BINARY -- an uninterpreted array of bytes, length in the
  * element header
  *
- * DCM_CLASS_SEQUENCE -- Value Representation is a seqeunce
+ * DCM_CLASS_SEQUENCE -- Value Representation is a sequence
  */
 typedef enum _DcmVRClass {
     DCM_CLASS_ERROR,

--- a/meson.build
+++ b/meson.build
@@ -190,12 +190,14 @@ executable(
   'tools/dcm-dump.c',
   dependencies : [libdicom_dep],
   install : true,
+  install_tag : 'bin',
 )
 executable(
   'dcm-getframe',
   'tools/dcm-getframe.c',
   dependencies : [libdicom_dep],
   install : true,
+  install_tag : 'bin',
 )
 
 dcm_dump_man = configure_file(

--- a/src/dicom-parse.c
+++ b/src/dicom-parse.c
@@ -263,7 +263,7 @@ static bool parse_element_header(DcmParseState *state,
     }
 
     if (state->implicit) {
-        // this can be an ambiguious VR, eg. pixeldata is allowed in implicit
+        // this can be an ambiguous VR, eg. pixeldata is allowed in implicit
         // mode and has to be disambiguated later from other tags
         *vr = dcm_vr_from_tag(*tag);
         if (*vr == DCM_VR_ERROR) {


### PR DESCRIPTION
Meson &ge; 0.60 lets users filter the installed files with `meson install --tags`.  Tell Meson that the tools are "executables bundled with a library meant to be used by end users".  Older Meson versions complain about the `install_tags` argument but don't fail:

    WARNING: Passed invalid keyword argument "install_tag"